### PR TITLE
Feat/devise japanese

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,9 @@
 class HomeController < ApplicationController
+  # リクエストしてきたユーザーを認証する。
+  # ユーザーがログイン済みの場合はアクセスを許可して、未ログインの場合はroot_pathにリダイレクトする。
+  before_action :authenticate_user!
+
   def index
   end
 end
+

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,1 +1,12 @@
 @import "~bootstrap/scss/bootstrap";
+
+// カスタムボタンスタイル
+.custom-btn {
+  width: 300px;  // 幅を150pxに設定
+  display: inline-block;  // ボタンをインラインブロック要素として扱う
+}
+
+.lead.mb-4 {
+    font-weight: bold;  // フォントを太字に設定
+  }
+  

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -1,0 +1,22 @@
+class CustomDeviseMailer < Devise::Mailer
+  helper :application  # ビューヘルパーを使用する場合
+  
+  # メール送信時のデフォルトロケールを日本語に設定
+  def confirmation_instructions(record, token, opts={})
+    I18n.with_locale(:ja) do
+      super
+    end
+  end
+  
+  def reset_password_instructions(record, token, opts={})
+    I18n.with_locale(:ja) do
+      super
+    end
+  end
+
+  def unlock_instructions(record, token, opts={})
+    I18n.with_locale(:ja) do
+      super
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable, :confirmable
   
   validates :name, presence: true
+  
 end

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -4,10 +4,10 @@
       <h1 class="mb-3">Dash Boards</h1>
       <p class="lead mb-4">Hello, sample!</p>
       <div class="mb-3">
-        <%= link_to '編集', edit_user_registration_path, class: 'btn btn-primary btn-lg mb-2' %>
+        <%= link_to '編集', edit_user_registration_path, class: 'btn btn-primary btn-lg mb-2 custom-btn' %>
       </div>
       <div class="mb-3">
-        <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'btn btn-warning btn-lg' %>
+        <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'btn btn-warning btn-lg custom-btn' %>
       </div>
     </div>
   </div>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -2,7 +2,7 @@
   <div class="row justify-content-center">
     <div class="col-md-6 text-center">
       <h1 class="mb-3">Dash Boards</h1>
-      <p class="lead mb-4">Hello, sample!</p>
+      <p class="lead mb-4"><%= current_user.name %></p>
       <div class="mb-3">
         <%= link_to '編集', edit_user_registration_path, class: 'btn btn-primary btn-lg mb-2 custom-btn' %>
       </div>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,18 +1,18 @@
 <div class="container mt-5">
   <div class="row justify-content-center">
     <div class="col-md-6">
-      <h2 class="mb-3 text-center">Resend confirmation instructions</h2>
+      <h2 class="mb-3 text-center"><%= t('devise.confirmations.new.resend_confirmation_instructions') %></h2>
 
       <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { class: 'needs-validation', novalidate: true }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
 
         <div class="mb-3">
-          <%= f.label :email, class: 'form-label' %>
+          <%= f.label :email, t('devise.confirmations.new.email'), class: 'form-label' %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control', value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
         </div>
 
         <div class="actions mb-3 text-center">
-          <%= f.submit "Resend confirmation instructions", class: 'btn btn-primary' %>
+          <%= f.submit t('devise.confirmations.new.submit_button'), class: 'btn btn-primary' %>
         </div>
       <% end %>
 

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
-<p>Welcome <%= @email %>!</p>
+<p><%= t('devise.mailer.confirmation_instructions.greeting', email: @resource.email) %></p>
 
-<p>You can confirm your account email through the link below:</p>
+<p><%= t('devise.mailer.confirmation_instructions.instruction') %></p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to t('devise.mailer.confirmation_instructions.confirm_my_account'), confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('devise.mailer.reset_password_instructions.greeting', email: @resource.email) %></p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p><%= t('devise.mailer.reset_password_instructions.someone_requested') %></p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to t('devise.mailer.reset_password_instructions.change_my_password'), edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= t('devise.mailer.reset_password_instructions.ignore') %></p>
+<p><%= t('devise.mailer.reset_password_instructions.warning') %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="container mt-5">
   <div class="row justify-content-center">
     <div class="col-md-6">
-      <h2 class="mb-3 text-center">Change your password</h2>
+      <h2 class="mb-3 text-center"><%= t('devise.passwords.edit.change_your_password') %></h2>
 
       <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: 'needs-validation', novalidate: true }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
@@ -9,22 +9,22 @@
         <%= f.hidden_field :reset_password_token %>
 
         <div class="mb-3">
-          <%= f.label :password, "New password", class: 'form-label' %>
+          <%= f.label :password, t('devise.passwords.edit.new_password'), class: 'form-label' %>
           <div class="d-flex align-items-baseline">
             <% if @minimum_password_length %>
-              <em class="ms-1">( <%= @minimum_password_length %> characters minimum)</em>
+              <em class="ms-1">( <%= t('devise.registrations.new.characters_minimum', count: @minimum_password_length) %> )</em>
             <% end %>
           </div>
           <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: 'form-control mt-2' %>
         </div>
 
         <div class="mb-3">
-          <%= f.label :password_confirmation, "Confirm new password", class: 'form-label' %>
+          <%= f.label :password_confirmation, t('devise.passwords.edit.confirm_new_password'), class: 'form-label' %>
           <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control' %>
         </div>
 
         <div class="actions mb-3 text-center">
-          <%= f.submit "Change my password", class: 'btn btn-primary' %>
+          <%= f.submit t('devise.passwords.edit.change_my_password'), class: 'btn btn-primary' %>
         </div>
       <% end %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,18 +1,18 @@
 <div class="container mt-5">
   <div class="row justify-content-center">
     <div class="col-md-6">
-      <h2 class="mb-3 text-center">Forgot your password?</h2>
+      <h2 class="mb-3 text-center"><%= t('devise.passwords.new.forgot_your_password') %></h2>
 
       <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { class: 'needs-validation', novalidate: true }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
 
         <div class="mb-3">
-          <%= f.label :email, class: 'form-label' %>
+          <%= f.label :email, t('devise.sessions.new.email'), class: 'form-label' %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
         </div>
 
         <div class="actions mb-3 text-center">
-          <%= f.submit "Send me reset password instructions", class: 'btn btn-primary' %>
+          <%= f.submit t('devise.passwords.new.send_me_reset_password_instructions'), class: 'btn btn-primary' %>
         </div>
       <% end %>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,56 +1,55 @@
 <div class="container mt-5">
   <div class="row justify-content-center">
     <div class="col-md-6">
-      <h2 class="mb-3 text-center">Edit <%= resource_name.to_s.humanize %></h2>
+      <h2 class="mb-3 text-center"><%= t('devise.registrations.edit.title', name: current_user.name) %></h2>
 
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: 'needs-validation', method: :put, novalidate: true }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
 
         <div class="mb-3">
-          <%= f.label :name, class: 'form-label' %>
+          <%= f.label :name, t('devise.registrations.edit.name'), class: 'form-label' %>
           <%= f.text_field :name, autofocus: true, autocomplete: "name", class: 'form-control' %>
         </div>
         
         <div class="mb-3">
-          <%= f.label :email, class: 'form-label' %>
+          <%= f.label :email, t('devise.registrations.edit.email'), class: 'form-label' %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
         </div>
 
         <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-          <div class="alert alert-info">Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+          <div class="alert alert-info"><%= t('devise.registrations.edit.pending_confirmation', email: resource.unconfirmed_email) %></div>
         <% end %>
 
         <div class="mb-3">
-          <%= f.label :password, class: 'form-label' %><i>(leave blank if you don't want to change it)</i>
+          <%= f.label :password, t('devise.registrations.edit.password') + " " + t('devise.registrations.edit.leave_blank_if_no_change'), class: 'form-label', style: "white-space: nowrap;" %>
           <%= f.password_field :password, autocomplete: "new-password", class: 'form-control' %>
-          <% if @minimum_password_length %>
-            <small class="form-text text-muted"><%= @minimum_password_length %> characters minimum</small>
-          <% end %>
         </div>
+        <% if @minimum_password_length %>
+          <small class="form-text text-muted"><%= t('devise.registrations.edit.minimum_password_length', count: @minimum_password_length) %></small>
+        <% end %>
 
         <div class="mb-3">
-          <%= f.label :password_confirmation, class: 'form-label' %>
+          <%= f.label :password_confirmation, t('devise.registrations.edit.confirm_passwords'), class: 'form-label' %>
           <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control' %>
         </div>
 
         <div class="mb-3">
-          <%= f.label :current_password, class: 'form-label' %><i>(we need your current password to confirm your changes)</i>
+          <%= f.label :current_password, raw(t('devise.registrations.edit.current_password')), class: 'form-label' %>
           <%= f.password_field :current_password, autocomplete: "current-password", class: 'form-control' %>
         </div>
 
         <div class="actions mb-3 text-center">
-          <%= f.submit "Update", class: 'btn btn-primary' %>
-          <h2 class="text-center mb-3">Cancel my account</h2>
+          <%= f.submit t('devise.registrations.edit.update'), class: 'btn btn-primary' %>
         </div>
         
         <div class="text-center mt-4">
           <div class="text-sm text-red-500 mb-3">
-            Unhappy? You can cancel your account.
+            <%= t('devise.registrations.edit.unhappy_question') %>
           </div>
-            <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: 'btn btn-danger mb-2' %>
-          </div>
-        <div class="text-center mt-3">
-          <%= link_to "Back", :back, class: 'btn btn-secondary' %>
+          <%= link_to t('devise.registrations.edit.cancel_account'), registration_path(resource_name), data: { confirm: t('devise.registrations.edit.confirm') }, method: :delete, class: 'btn btn-danger mb-2' %>
+        </div>
+        <div style="text-align: left;">
+          <%= link_to t('devise.registrations.edit.back'), :back, class: 'text-link' %>
         </div>
       <% end %>
     </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,38 +1,38 @@
 <div class="container mt-5">
   <div class="row justify-content-center">
     <div class="col-md-6">
-      <h2 class="mb-3 text-center">Sign up</h2>
+      <h2 class="mb-3 text-center"><%= t('devise.registrations.new.sign_up') %></h2>
 
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: 'needs-validation', novalidate: true }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
 
         <div class="mb-3">
-          <%= f.label :name, class: 'form-label' %>
+          <%= f.label :name, t('devise.registrations.new.name'), class: 'form-label' %>
           <%= f.text_field :name, autofocus: true, autocomplete: "name", class: 'form-control' %>
         </div>
 
         <div class="mb-3">
-          <%= f.label :email, class: 'form-label' %>
+          <%= f.label :email, t('devise.registrations.new.email'), class: 'form-label' %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
         </div>
 
         <div class="mb-3">
           <div class="d-flex align-items-baseline">
-            <%= f.label :password, class: 'form-label' %>
+            <%= f.label :password, t('devise.registrations.new.password'), class: 'form-label' %>
             <% if @minimum_password_length %>
-              <em class="ms-1">( <%= @minimum_password_length %> characters minimum)</em>
+              <em class="ms-1">( <%= t('devise.registrations.new.characters_minimum', count: @minimum_password_length) %> )</em>
             <% end %>
           </div>
           <%= f.password_field :password, autocomplete: "new-password", class: 'form-control mt-2' %>
         </div>
 
         <div class="mb-3">
-          <%= f.label :password_confirmation, class: 'form-label' %>
+          <%= f.label :password_confirmation, t('devise.registrations.new.password_confirmation'), class: 'form-label' %>
           <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control' %>
         </div>
 
         <div class="actions mb-3 text-center">
-          <%= f.submit "Sign up", class: 'btn btn-primary' %>
+          <%= f.submit t('devise.registrations.new.sign_up_button'), class: 'btn btn-primary' %>
         </div>
       <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,28 +1,28 @@
 <div class="container mt-5">
   <div class="row justify-content-center">
     <div class="col-md-6">
-      <h2 class="mb-3 text-center">Log in</h2>
+      <h2 class="mb-3 text-center"><%= t('devise.sessions.new.log_in') %></h2>
 
       <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: 'needs-validation', novalidate: true }) do |f| %>
         <div class="mb-3">
-          <%= f.label :email, class: 'form-label' %>
+          <%= f.label :email, t('devise.sessions.new.email'), class: 'form-label' %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
         </div>
 
         <div class="mb-3">
-          <%= f.label :password, class: 'form-label' %>
+          <%= f.label :password, t('devise.sessions.new.password'), class: 'form-label' %>
           <%= f.password_field :password, autocomplete: "current-password", class: 'form-control' %>
         </div>
 
         <% if devise_mapping.rememberable? %>
           <div class="mb-3 form-check">
             <%= f.check_box :remember_me, class: 'form-check-input' %>
-            <%= f.label :remember_me, class: 'form-check-label' %>
+            <%= f.label :remember_me, t('devise.sessions.new.remember_me'), class: 'form-check-label' %>
           </div>
         <% end %>
 
         <div class="actions mb-3 text-center">
-          <%= f.submit "Log in", class: 'btn btn-primary' %>
+          <%= f.submit t('devise.sessions.new.log_in_button'), class: 'btn btn-primary' %>
         </div>
       <% end %>
 

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,7 +1,7 @@
 <% if resource.errors.any? %>
   <div id="error_explanation" data-turbo-cache="false">
     <h2>
-      <%= I18n.t("errors.messages.not_saved",
+      <%= I18n.t("devise.errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,25 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to t('devise.shared.links.log_in'), new_session_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to t('devise.shared.links.sign_up'), new_registration_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to t('devise.shared.links.forgot_password'), new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_user_confirmation_path %><br />
+  <%= link_to t('devise.shared.links.didnt_receive_confirmation_instructions'), new_user_confirmation_path %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <%= link_to t('devise.shared.links.didnt_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+    <%= button_to t('devise.shared.links.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
   <% end %>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,13 @@ module Sample1
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # 言語設定を追加
+    config.i18n.default_locale = :ja  # デフォルトの言語を日本語に設定
+    config.i18n.available_locales = [:en, :ja]  # 利用可能な言語
+
+    # フォールバック設定を追加
+    config.i18n.fallbacks = [:en]
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -26,6 +26,9 @@ Devise.setup do |config|
   # with default "from" parameter.
   config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
 
+  # カスタムメーラークラスを設定
+  config.mailer = 'CustomDeviseMailer'
+  
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
 

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -3,15 +3,16 @@ ja:
     mailer:
       reset_password_instructions:
         subject: "パスワードリセットのお知らせ"
-        greeting: "こんにちは、%{email}さん！"
-        someone_requested: "パスワードをリセットするためのリンクが要求されました。以下のリンクを通じて行うことができます。"
-        change_my_password: "パスワードを変更する"
-        ignore: "もしこのリクエストを行っていない場合は、このメールを無視してください。"
-        warning: "パスワードは上記のリンクをアクセスして新しいものを作成するまで変更されません。"
+        greeting: "%{email}様"
+        someone_requested: "パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。"
+        change_my_password: "パスワード変更"
+        ignore: "パスワード再設定の依頼をしていない場合、このメールを無視してください。"
+        warning: "パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。"
       confirmation_instructions:
-        greeting: "ようこそ %{email}さん！"
-        instruction: "以下のリンクを通じてあなたのアカウントのメールアドレスを確認できます："
-        confirm_my_account: "アカウントを確認する"
+        subject: "メールアドレス確認メール"
+        greeting: "%{email}様"
+        instruction: "以下のリンクをクリックし、メールアドレスの確認手順を完了させてください。"
+        confirm_my_account: "メールアドレスの確認"
     sessions:
       new:
         log_in: "ログイン"
@@ -21,8 +22,13 @@ ja:
         log_in_button: "ログイン"
     passwords:
       new:
-        forgot_your_password: "パスワードをお忘れですか？"
+        forgot_your_password: "パスワードを忘れましたか？"
         send_me_reset_password_instructions: "パスワードの再設定メールを送信する"
+      edit:
+        change_your_password: "パスワードの変更"
+        new_password: "新しいパスワード"
+        confirm_new_password: "新しいパスワードの確認"
+        change_my_password: "パスワードを変更する"
     confirmations:
       new:
         resend_confirmation_instructions: "アカウント確認のメールを受け取っていませんか？"
@@ -37,6 +43,19 @@ ja:
         password_confirmation: "パスワード確認"
         characters_minimum: "%{count}文字以上"
         sign_up_button: "登録する"
+      edit:
+        title: "%{name}の編集"
+        name: "名前"
+        email: "メールアドレス"
+        password: "パスワード"
+        leave_blank_if_no_change: "(空欄のままなら変更しません)"
+        minimum_password_length: "%{count}文字以上"
+        confirm_passwords: "パスワード(確認用)"
+        current_password: "現在のパスワード<br>（変更を反映するには現在のパスワードを入力してください）"
+        update: "更新"
+        unhappy_question: "気に入りません"
+        cancel_account: "アカウント削除"
+        back: "戻る"
     shared:
       links:
         log_in: "ログイン"
@@ -50,4 +69,4 @@ ja:
         not_saved:
           one: "1件のエラーが発生したためユーザーは保存されませんでした。"
           other: "%{count}件のエラーが発生したためユーザーは保存されませんでした。"
-          
+      

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,31 @@
+ja:
+  devise:
+    sessions:
+      new:
+        log_in: "ログイン"
+        email: "メールアドレス"
+        password: "パスワード"
+        remember_me: "ログイン状態を保持する"
+        log_in_button: "ログイン"
+    registrations:
+      new:
+        sign_up: "新規登録"
+        name: "名前"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード確認"
+        characters_minimum: "%{count}文字以上"
+        sign_up_button: "登録する"
+    shared:
+      links:
+        log_in: "ログイン"
+        sign_up: "新規登録"
+        forgot_password: "パスワードを忘れた方はこちら"
+        didnt_receive_confirmation_instructions: "確認メールが届いていない方はこちら"
+        didnt_receive_unlock_instructions: "アンロック指示が届いていない方はこちら"
+        sign_in_with_provider: "%{provider}でサインイン"
+    errors:
+      messages:
+        not_saved:
+          one: "1つのエラーにより %{resource} を保存できませんでした："
+          other: "%{count} つのエラーにより %{resource} を保存できませんでした："

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -5,11 +5,20 @@ ja:
         log_in: "ログイン"
         email: "メールアドレス"
         password: "パスワード"
-        remember_me: "ログイン状態を保持する"
+        remember_me: "次回から自動的にログイン"
         log_in_button: "ログイン"
+    passwords:
+      new:
+        forgot_your_password: "パスワードをお忘れですか？"
+        send_me_reset_password_instructions: "パスワードの再設定メールを送信する"
+    confirmations:
+      new:
+        resend_confirmation_instructions: "アカウント確認のメールを受け取っていませんか？"
+        submit_button: "アカウント確認メール再送"
+        email: "メールアドレス"
     registrations:
       new:
-        sign_up: "新規登録"
+        sign_up: "アカウント登録"
         name: "名前"
         email: "メールアドレス"
         password: "パスワード"
@@ -19,13 +28,14 @@ ja:
     shared:
       links:
         log_in: "ログイン"
-        sign_up: "新規登録"
-        forgot_password: "パスワードを忘れた方はこちら"
-        didnt_receive_confirmation_instructions: "確認メールが届いていない方はこちら"
+        sign_up: "アカウント登録"
+        forgot_password: "パスワードを忘れましたか？"
+        didnt_receive_confirmation_instructions: "アカウント確認のメールを受け取っていませんか？"
         didnt_receive_unlock_instructions: "アンロック指示が届いていない方はこちら"
         sign_in_with_provider: "%{provider}でサインイン"
     errors:
       messages:
         not_saved:
-          one: "1つのエラーにより %{resource} を保存できませんでした："
-          other: "%{count} つのエラーにより %{resource} を保存できませんでした："
+          one: "1件のエラーが発生したためユーザーは保存されませんでした。"
+          other: "%{count}件のエラーが発生したためユーザーは保存されませんでした。"
+          

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,5 +1,17 @@
 ja:
   devise:
+    mailer:
+      reset_password_instructions:
+        subject: "パスワードリセットのお知らせ"
+        greeting: "こんにちは、%{email}さん！"
+        someone_requested: "パスワードをリセットするためのリンクが要求されました。以下のリンクを通じて行うことができます。"
+        change_my_password: "パスワードを変更する"
+        ignore: "もしこのリクエストを行っていない場合は、このメールを無視してください。"
+        warning: "パスワードは上記のリンクをアクセスして新しいものを作成するまで変更されません。"
+      confirmation_instructions:
+        greeting: "ようこそ %{email}さん！"
+        instruction: "以下のリンクを通じてあなたのアカウントのメールアドレスを確認できます："
+        confirm_my_account: "アカウントを確認する"
     sessions:
       new:
         log_in: "ログイン"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,16 @@
+ja:
+  errors:
+    format: "%{message}"  # エラーメッセージにモデル名を含めない設定
+  activerecord:
+    models:
+      user: "ユーザー"  # User モデルの日本語名
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              blank: "メールアドレスを入力してください"
+            password:
+              blank: "パスワードを入力してください"
+            name:
+              blank: "名前を入力してください"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,16 +1,22 @@
 ja:
   errors:
-    format: "%{message}"  
+    format: "%{message}"
+    messages:
+      already_confirmed: "すでに確認されています。サインインしてみてください"
+      expired: "パスワードを入力してください"
   activerecord:
     models:
-      user: "ユーザー" 
+      user: "ユーザー"
     errors:
       models:
         user:
           attributes:
-            email:
-              blank: "名前を入力してください"
-            password:
-              blank: "Eメールを入力してください"
-            name:
+            current_password:
               blank: "パスワードを入力してください"
+            email:
+              blank: "Eメールを入力してください"
+            password:
+              blank: "パスワードを入力してください"
+            name:
+              blank: "名前を入力してください"
+            

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,16 +1,16 @@
 ja:
   errors:
-    format: "%{message}"  # エラーメッセージにモデル名を含めない設定
+    format: "%{message}"  
   activerecord:
     models:
-      user: "ユーザー"  # User モデルの日本語名
+      user: "ユーザー" 
     errors:
       models:
         user:
           attributes:
             email:
-              blank: "メールアドレスを入力してください"
-            password:
-              blank: "パスワードを入力してください"
-            name:
               blank: "名前を入力してください"
+            password:
+              blank: "Eメールを入力してください"
+            name:
+              blank: "パスワードを入力してください"

--- a/db/migrate/20240418104050_add_locale_to_users.rb
+++ b/db/migrate/20240418104050_add_locale_to_users.rb
@@ -1,0 +1,5 @@
+class AddLocaleToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :locale, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_09_113346) do
+ActiveRecord::Schema.define(version: 2024_04_18_104050) do
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2024_04_09_113346) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.string "locale"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,8 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+user = User.find_or_initialize_by(email: "sample@email.com")
+if user.new_record?
+  user.name = "Sample User"
+  user.password = "password"
+  user.password_confirmation = "password"
+  user.confirmed_at = nil
+  user.save!
+end

--- a/test/mailers/custom_devise_mailer_test.rb
+++ b/test/mailers/custom_devise_mailer_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CustomDeviseMailerTest < ActionMailer::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/mailers/previews/custom_devise_mailer_preview.rb
+++ b/test/mailers/previews/custom_devise_mailer_preview.rb
@@ -1,0 +1,19 @@
+class CustomDeviseMailerPreview < ActionMailer::Preview
+  # パスワードリセットの指示をプレビューする
+  def reset_password_instructions
+    user = User.first || User.new(email: "preview@example.com", reset_password_token: "faketoken")
+    CustomDeviseMailer.reset_password_instructions(user, "faketoken")
+  end
+
+  # 確認指示のメールをプレビューする
+  def confirmation_instructions
+    user = User.first || User.new(email: "preview@example.com", confirmation_token: "faketoken")
+    CustomDeviseMailer.confirmation_instructions(user, "faketoken")
+  end
+
+  # アンロック指示のメールをプレビューする
+  def unlock_instructions
+    user = User.first || User.new(email: "preview@example.com", unlock_token: "faketoken")
+    CustomDeviseMailer.unlock_instructions(user, "faketoken")
+  end
+end


### PR DESCRIPTION
### PR概要
ステップ5. gem 'devise'を使ったログイン機能の実装（その3）
devise_japanese
・Mind map に則り遷移画面が実装できること。
・ログイン画面
・新規登録画面
・パスワード再設定画面
・認証メール再設定画面
・letter_opener_webでの受信確認
・password/edit画面
・user/dash_borads画面
・ユーザーの編集画面

### 実装画面スクショを添付したスプシのリンク
https://docs.google.com/spreadsheets/d/1mdctCV4q0oeH2I6GYuMKyzCiO_zPCH-UF59jXOZz9A0/edit#gid=573837786
